### PR TITLE
fix #16: The correct tags are now displayed

### DIFF
--- a/karate-core/src/main/java/com/intuit/karate/core/ScenarioResult.java
+++ b/karate-core/src/main/java/com/intuit/karate/core/ScenarioResult.java
@@ -169,18 +169,12 @@ public class ScenarioResult implements Comparable<ScenarioResult> {
         FeatureSection section = feature.getSection(sectionIndex);
         Scenario scenario = new Scenario(feature, section, exampleIndex, exampleTableIndex);
         if (section.isOutline()) {
-            // This can never be null, since an outline is used in conjunction with example tables
-            List<ExamplesTable> tables = section.getScenarioOutline().getExamplesTables(); 
-            
-            // This is initialized as an empty arrayList and never set to null in the codebase
-            List<Tag> tags = tables.get(exampleTableIndex).getTags();
-
-            // This however can be set to null
-            List<Tag> outlineTags = section.getScenarioOutline().getTags();
+            List<ExamplesTable> tables = section.getScenarioOutline().getExamplesTables(); // This can never be null, since an outline is used in conjunction with example tables
+            List<Tag> tags = tables.get(exampleTableIndex).getTags();// This is initialized as an empty arrayList and never set to null in the codebase
+            List<Tag> outlineTags = section.getScenarioOutline().getTags(); // This however can be set to null
             if (outlineTags != null) {
                 tags.addAll(outlineTags);
             }
-
             scenario.setTags(tags);
             scenario.setDescription(section.getScenarioOutline().getDescription());
         } else {


### PR DESCRIPTION
Fixes #16 : When using tagged example tables, the correct tags now display next to the results of the summary page.

This pull request also includes #20 because it hasn't been merged yet and my fixes required the use of the exampleTableIndex. Both should be merged separately to ensure that the work of @augustyvdal is visible on the commit history.